### PR TITLE
Update translation.

### DIFF
--- a/content/Requiring-files.md
+++ b/content/Requiring-files.md
@@ -80,8 +80,8 @@ The **relative path** is relative to the current file. The **absolute path** is 
 
 No, you do not have to use *.js*, but it highlights better what you are requiring. You might have some .js files, and some .jsx files and even images and css can be required by Webpack. It also clearly differs from required node_modules and specific files.
    
-不，你不需要去特意去使用 *.js*，但是如果你引入之后高亮会更好。你可能有一些 .js 文件和一些 .jsx 文件，甚至一些图片和 css 可以用 Webpack 引入，甚至可以直接引入 node_modules 里的代码和特殊文件。
+不，你不需要去特意去使用 *.js*，但是他能够更让你更清楚你正引入的档案。因為你可能有一些 .js 文件和一些 .jsx 文件，甚至一些图片和 css 可以用 Webpack 來引入。加入文件后缀，可以让你清楚地区分你引入的是 node_modules 或特定档案还是一般文件档案。
 
 Remember that Webpack is a module bundler! This means you can set it up to load any format you want given there is a loader for it. We'll delve into this topic later on.
 
-记住，Webpack 只是一个模块合并！也就是说你可以设置他去加载任何你写的匹配，只要有一个加载器。我们稍后会继续深入这个话题。
+记住，Webpack 只是一个模块合并器！也就是说你可以设置他去加载任何你写的匹配，只要有一个加载器。我们稍后会继续深入这个话题。


### PR DESCRIPTION
Thanks for your zh-cn translation :)
In a paragraph of Requiring-files.md, 

---

No, you do not have to use .js, but it highlights better what you are requiring. You might have some .js files, and some .jsx files and even images and css can be required by Webpack. It also clearly differs from required node_modules and specific files.

---

I think the meaning in zh-cn may be differ from English version. 
Therefore, I do some changes. I think this translation is more appropriate.
Please check it :)
